### PR TITLE
Replace Unidecode with anyascii

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author='Pascal van Kooten',
     url='https://github.com/kootenpv/textsearch',
     author_email='kootenpv@gmail.com',
-    install_requires=["pyahocorasick", "Unidecode"],
+    install_requires=["anyascii", "pyahocorasick"],
     classifiers=[
         'Intended Audience :: Developers',
         'Intended Audience :: Customer Service',

--- a/textsearch/__init__.py
+++ b/textsearch/__init__.py
@@ -1,6 +1,6 @@
 import re
 import string
-import unidecode
+from anyascii import anyascii
 import ahocorasick
 
 ALPHANUM = set(string.digits + string.ascii_letters + '_')
@@ -294,7 +294,7 @@ class TextSearch(object):
         del self._root_dict[k]
         self.words_changed = True
         if self.replace_foreign_chars:
-            k = unidecode.unidecode(k)
+            k = anyascii(k)
         if self.case == "smart":
             self.automaton.remove_word(k)
             self.automaton.remove_word(k.lower())
@@ -355,7 +355,7 @@ class TextSearch(object):
         self._root_dict[k] = v
         self.words_changed = True
         if self.replace_foreign_chars:
-            k = unidecode.unidecode(k)
+            k = anyascii(k)
 
         v = k if v is None else v
         length = len(k)
@@ -383,7 +383,7 @@ class TextSearch(object):
         self.automaton.make_automaton()
         self.words_changed = False
         if self.replace_foreign_chars:
-            text = unidecode.unidecode(text)
+            text = anyascii(text)
         _text = text.lower() if self._ignore_case_in_search else text
         if not self.handlers and not self.left_bound_chars and not self.right_bound_chars:
             for end_index, (length, norm) in self.automaton.iter(_text):
@@ -414,7 +414,7 @@ class TextSearch(object):
         """
         self.build_automaton()
         if self.replace_foreign_chars:
-            text = unidecode.unidecode(text)
+            text = anyascii(text)
         keywords = []
         current_stop = -1
         _text = text.lower() if self._ignore_case_in_search else text
@@ -474,7 +474,7 @@ class TextSearch(object):
         """
         self.build_automaton()
         if self.replace_foreign_chars:
-            text = unidecode.unidecode(text)
+            text = anyascii(text)
         keywords = []
         _text = text.lower() if self._ignore_case_in_search else text
         if not self.handlers and not self.left_bound_chars and not self.right_bound_chars:
@@ -547,7 +547,7 @@ class TextSearch(object):
             raise ValueError("no idea how i would do that")
         self.build_automaton()
         if self.replace_foreign_chars:
-            text = unidecode.unidecode(text)
+            text = anyascii(text)
         keywords = [(None, None, 0, ("", ""))]
         current_stop = -1
         _text = text.lower() if self._ignore_case_in_search else text
@@ -630,7 +630,7 @@ class TextSearch(object):
     def __contains__(self, key):
         # note that smart includes lowercase, so it's an easy check
         if self.replace_foreign_chars:
-            key = unidecode.unidecode(key)
+            key = anyascii(key)
         if self._ignore_case_in_search or self.case == "smart":
             return key.lower() in self.automaton
         return key in self.automaton

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ deps =
     pytest-cov
     coveralls
     pyahocorasick
-    Unidecode
 commands =
     py.test --cov
     coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 setenv =
     PYTHON_ENV = dev
 deps =
+    anyascii
     pytest
     pytest-cov
     coveralls


### PR DESCRIPTION
This PR should solve issue #1. 

The actual replacement of Unidecode usages with anyascii was straightforward. I manually ran the tests and no problems there. 

I was not able to get tox and pyenv to behave as required on my machine. I also don't know how we check for execution speed and if there are any changes in it with the usage of anyascii.

It would be great if you can look into this @kootenpv 

Thanks! 